### PR TITLE
feat: sets ft for local outputpanel buffer

### DIFF
--- a/lua/output_panel/init.lua
+++ b/lua/output_panel/init.lua
@@ -40,6 +40,7 @@ function M.panel()
 
   vim.api.nvim_win_set_buf(0, output_panel_bufnr)
   vim.api.nvim_win_set_height(0, 30)
+  vim.opt_local.filetype = "OutputPanel"
   vim.wo.number = false
   vim.wo.scrolloff = 0
   vim.wo.winbar = [[%{%v:lua.require('output_panel').winbar()%}]]

--- a/lua/output_panel/init.lua
+++ b/lua/output_panel/init.lua
@@ -40,7 +40,7 @@ function M.panel()
 
   vim.api.nvim_win_set_buf(0, output_panel_bufnr)
   vim.api.nvim_win_set_height(0, 30)
-  vim.opt_local.filetype = "OutputPanel"
+  vim.bo[output_panel_bufnr].ft = "outputpanel"
   vim.wo.number = false
   vim.wo.scrolloff = 0
   vim.wo.winbar = [[%{%v:lua.require('output_panel').winbar()%}]]


### PR DESCRIPTION
I like to set up custom things based on `filetype`, such as binding `q` to quit in normal mode, for a specific filetype, or list of filetypes.

This opens up that possibility.