### PR TITLE
fix: don't crash after many logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]
-        nvim-version: [v0.8.3, v0.9.5, v0.10.4]
+        nvim-version: [v0.8.3, v0.9.5, v0.10.4, v0.11.6]
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         nvim-version: [v0.8.3, v0.9.5, v0.10.4, v0.11.6]
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
       - uses: leafo/gh-actions-lua@v12
         with:
           luaVersion: "5.1.5"

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
         };
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
+            alejandra
+            wget
             bash
             luarocks
             lua5_1

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ deps:
   #!/usr/bin/env bash
   set -euo pipefail
   if [ ! -d "nvim-test" ]; then
-    git clone --depth 1 --branch v1.1.1 https://github.com/lewis6991/nvim-test
+    git clone --depth 1 --branch v1.3.0 https://github.com/lewis6991/nvim-test
   fi
 
 init: deps

--- a/lua/output_panel/init.lua
+++ b/lua/output_panel/init.lua
@@ -25,10 +25,10 @@ function P.create_tab(name)
     end
   end
 
-  P.create_tab(coroutine.yield(tabs[name]))
+  return tabs[name]
 end
 
-local create_tab = coroutine.wrap(P.create_tab)
+-- local create_tab = coroutine.wrap(P.create_tab)
 
 local M = {}
 
@@ -82,7 +82,7 @@ function M.setup(opts)
       local client_id = context.client_id
       local client = vim.lsp.get_client_by_id(client_id)
       if client then
-        local tab = create_tab(client.name)
+        local tab = P.create_tab(client.name)
 
         local message =
           vim.split("[" .. vim.lsp.protocol.MessageType[result.type] .. "] " .. result.message, "\n")

--- a/spec/output_panel_spec.lua
+++ b/spec/output_panel_spec.lua
@@ -64,3 +64,30 @@ make the buffer overflow]])
     }, lines)
   end)
 end)
+describe("output panel", function()
+  before_each(function()
+    helpers.clear()
+
+    exec_lua([[
+      vim.opt.rtp:append'.'
+      vim.lsp.get_client_by_id = function()
+        return {name = "foobar lsp"}
+      end
+      require('output_panel').setup({max_buffer_size = 5000})
+    ]])
+
+    log("this is a really\nmessage\nthat everyone should see")
+  end)
+
+  it("should work even with a ton of logs", function()
+    for i = 1, 100000, 1 do
+      log("this is a really\nmessage\nthat everyone should see" .. i)
+    end
+    local lines = exec_lua([[
+      vim.cmd.OutputPanel()
+      return vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    ]])
+
+    eq(#lines, 5000)
+  end)
+end)


### PR DESCRIPTION
This was crashing because it was actually recursively calling a function
a million times inside a coroutine, eventually it just hit a stack
overflow.

I don't think the coroutine was doing anything important, it was a
previous attempt at making it "async", but I think the real performance
win before was moving to not re-rendering things and using the circular
buffer.

Closes #5 